### PR TITLE
Merge Relevancy Search Features to main

### DIFF
--- a/src/main/java/furnitureCatalogue/Login.java
+++ b/src/main/java/furnitureCatalogue/Login.java
@@ -46,12 +46,12 @@ public class Login {
     }
 
     protected String readPassword(String prompt) {
-        Console console = System.console();
-        if (console == null) {
+//        Console console = System.console();
+        if (System.console() == null) {
             System.out.print(prompt);
             return scanner.nextLine();
         } else {
-            char[] passwordArray = console.readPassword(prompt);
+            char[] passwordArray = System.console().readPassword(prompt);
             return new String(passwordArray);
         }
     }

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchController.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchController.java
@@ -41,8 +41,6 @@ public class SearchController {
     }
     
     public void searchQuery() {
-        this.filters.clear(); // Clear previous filters
-        this.ranges.clear();
         query = view.getQuery();
         sortCategory = view.getSortCategory();
         sortMode = view.getSortMode();

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
@@ -30,10 +30,12 @@ public class SearchModel {
         return m;
     }
 
-    public void query() {
+    // Runs entire search routine, should only ever be run from searchController.
+    protected void query() {
         String url = "src/main/resources/" + fileName;
         String order = controller.sortMode ? " ASC" : " DESC";
-        String query = controller.query;
+        String query = controller.query.replace(" ","%");
+        // Filter requires additional formatting. Filters are used to build chunk of an sql query
         String filter = "";
         for (String s : controller.filters.keySet()) {
             filter += s + " = '" + controller.filters.get(s) + "' AND ";
@@ -42,21 +44,21 @@ public class SearchModel {
             filter += s + " BETWEEN " + controller.ranges.get(s).get(0)
                     + " AND " + controller.ranges.get(s).get(1) + " AND ";
         }
-        // Remove trailing " AND "
+
+        // Fix any lingering formatting issues from concatenations
         if(!filter.isEmpty()) {
             filter = filter.substring(0, filter.length() - 4);
             filter = "WHERE " + filter;
         }
 
+        // Database is created locally in memory only reading from the main csv
         try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:")) {
+            // Load main csv into table
             PreparedStatement load = connection.prepareStatement(
                     "CREATE TABLE t AS SELECT * FROM CSVREAD('" + url + "')");
             load.execute();
 
-            String format = formatQuery(query, connection);
-//            PreparedStatement search = connection.prepareStatement(format);
-//            ResultSet queryStepOne = search.executeQuery();
-
+            // Integer columns are by default loaded as strings, this converts them back to integers
             PreparedStatement reformat = connection.prepareStatement(
                     "ALTER TABLE t ALTER COLUMN id INTEGER;" +
                     "ALTER TABLE t ALTER COLUMN Quantity INTEGER;" +
@@ -64,11 +66,13 @@ public class SearchModel {
                     "ALTER TABLE t ALTER COLUMN Price INTEGER;");
             reformat.execute();
 
+            // Main query that generates final result
+            String format = formatQuery(query);
             PreparedStatement searchFilter = connection.prepareStatement("(" + format +
                     ") INTERSECT SELECT * FROM t " + filter + "ORDER BY " + controller.sortCategory + order);
-//            searchFilter.setString(1, query);
             ResultSet queryResult = searchFilter.executeQuery();
 
+            // Output results
             List<String> headers = Arrays.asList("Name", "Price", "Furniture Type", "Colour",
                                                    "Materials", "Size", "Quantity", "Company", "Style", "Weight");
             while (queryResult.next()) {
@@ -89,8 +93,9 @@ public class SearchModel {
         }
     }
 
-    private String formatQuery(String query, Connection conn) throws SQLException {
-        int depth = (query.length()/3) + 1;
+    // Generates chunk of sql query that allows for some typos in search entry
+    private String formatQuery(String query) {
+        int depth = (query.length()/3) + 1; // Represents how many wrong characters are permitted
         String formattedQuery = "SELECT * FROM t WHERE Name LIKE '%" + query + "%'";
         if(query.length() < 4) {
             return formattedQuery;
@@ -98,30 +103,33 @@ public class SearchModel {
         else if(query.length() == 6) {
             depth = 2;
         }
+        else if(query.length() > 9) {
+            depth = 3;
+        }
 
-        List<String> permutations = recursiveFormatQuery(new ArrayList<>(), query, depth, conn);
+        List<String> permutationsBase = recursiveFormatQuery(query, depth); // Recursive function
+        // Many results from recursion are unnecessary duplicates, this filters them out.
+        List<String> permutations = new ArrayList<>();
+        for(String s : permutationsBase) {
+            if(!permutations.contains(s)) {
+                permutations.add(s);
+            }
+        }
 
+        // Building the sql chunk
         for(String s : permutations) {
+            System.out.println(s);
             formattedQuery += " UNION SELECT * FROM t WHERE Name LIKE '%" + s + "%'";
         }
-//        System.out.println(formattedQuery);
         return formattedQuery;
     }
 
-    private List<String> recursiveFormatQuery (List<String> permutations, String query, int depth, Connection conn) throws SQLException {
-//        System.console().printf(query + "\n");
-//        System.console().printf(depth + "\n");
-
-//        formattedQuery += " UNION SELECT * FROM t WHERE Name LIKE '%" + query + "%'";
-
+    // Recursively adds different combinations of wildcards and stores them in a list
+    private List<String> recursiveFormatQuery (String query, int depth) {
+        List<String> permutations = new ArrayList<>();
         if(depth > 0) {
             for (int i = 0; i < query.length(); i++) {
-                List<String> newPermutations = recursiveFormatQuery(permutations, query.substring(0, i) + "_" + query.substring(i + 1), depth - 1, conn);
-                for(String s : newPermutations) {
-                    if(!(permutations.contains(s))) {
-                        permutations.add(s);
-                    }
-                }
+                permutations.addAll(recursiveFormatQuery(query.substring(0, i) + "_" + query.substring(i + 1), depth - 1));
             }
         }
         else {

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
@@ -55,6 +55,8 @@ public class SearchModel {
                     "ALTER TABLE t ALTER COLUMN Weight INTEGER;" +
                     "ALTER TABLE t ALTER COLUMN Price INTEGER;");
             reformat.execute();
+            System.out.println((query.length()/3) + 1);
+//            String format = formatQuery("astic", connection);
 
             PreparedStatement search = connection.prepareStatement(
                     "SELECT * FROM t WHERE " + filter + "Name LIKE ? ORDER BY " + controller.sortCategory + order);
@@ -81,28 +83,28 @@ public class SearchModel {
         }
     }
 
-    private List<PreparedStatement> formatQuery(String query, Connection conn) throws SQLException {
+    private String formatQuery(String query, Connection conn) throws SQLException {
         int depth = (query.length()/3) + 1;
+        String formattedQuery = "SELECT * FROM t WHERE Name LIKE '%" + query + "%'";
         if(query.length() < 4) {
-            List<PreparedStatement> queries = new ArrayList<>();
-            queries.add(conn.prepareStatement("SELECT * FROM t WHERE Name LIKE '%" + query + "%'"));
-            return queries;
+            return formattedQuery;
         }
         else if(query.length() == 6) {
             depth = 2;
         }
+        System.out.println(depth);
 
-        return recursiveFormatQuery(query, depth, conn);
+        return recursiveFormatQuery(formattedQuery, query, depth, conn);
     }
 
-    private List<PreparedStatement> recursiveFormatQuery (String query, int depth, Connection conn) throws SQLException {
-        List<PreparedStatement> queries = new ArrayList<>();
-        queries.add(conn.prepareStatement("SELECT * FROM t WHERE Name LIKE '%" + query + "%'"));
-        if(depth != 0) {
+    private String recursiveFormatQuery (String formattedQuery, String query, int depth, Connection conn) throws SQLException {
+//        System.out.println(query);
+        formattedQuery += " UNION SELECT * FROM t WHERE Name LIKE '%" + query + "%'";
+        if(depth > 0) {
             for (int i = 0; i < query.length(); i++) {
-                queries.addAll(recursiveFormatQuery(query.substring(0, i) + "_" + query.substring(i + 2), depth - 1, conn));
+                query += recursiveFormatQuery(formattedQuery, query.substring(0, i) + "_" + query.substring(i + 2), depth - 1, conn);
             }
         }
-        return queries;
+        return query;
     }
 }

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
@@ -80,4 +80,29 @@ public class SearchModel {
             e.printStackTrace();
         }
     }
+
+    private List<PreparedStatement> formatQuery(String query, Connection conn) throws SQLException {
+        int depth = (query.length()/3) + 1;
+        if(query.length() < 4) {
+            List<PreparedStatement> queries = new ArrayList<>();
+            queries.add(conn.prepareStatement("SELECT * FROM t WHERE Name LIKE '%" + query + "%'"));
+            return queries;
+        }
+        else if(query.length() == 6) {
+            depth = 2;
+        }
+
+        return recursiveFormatQuery(query, depth, conn);
+    }
+
+    private List<PreparedStatement> recursiveFormatQuery (String query, int depth, Connection conn) throws SQLException {
+        List<PreparedStatement> queries = new ArrayList<>();
+        queries.add(conn.prepareStatement("SELECT * FROM t WHERE Name LIKE '%" + query + "%'"));
+        if(depth != 0) {
+            for (int i = 0; i < query.length(); i++) {
+                queries.addAll(recursiveFormatQuery(query.substring(0, i) + "_" + query.substring(i + 2), depth - 1, conn));
+            }
+        }
+        return queries;
+    }
 }

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
@@ -118,7 +118,6 @@ public class SearchModel {
 
         // Building the sql chunk
         for(String s : permutations) {
-            System.out.println(s);
             formattedQuery += " UNION SELECT * FROM t WHERE Name LIKE '%" + s + "%'";
         }
         return formattedQuery;

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
@@ -27,10 +27,12 @@ public class SearchModel {
         if (Objects.isNull(m)) {
             m = new SearchModel();
         }
+        System.out.println("I print something!");
         return m;
     }
 
     public void query() {
+        System.out.println("1");
         String url = "src/main/resources/" + fileName;
         String order = controller.sortMode ? " ASC" : " DESC";
         String query = "%" + controller.query + "%";
@@ -43,11 +45,13 @@ public class SearchModel {
                     + " AND " + controller.ranges.get(s).get(1) + " AND ";
         }
         // Remove trailing " AND "
+        System.out.println("2");
 
         try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:")) {
             PreparedStatement load = connection.prepareStatement(
                     "CREATE TABLE t AS SELECT * FROM CSVREAD('" + url + "')");
             load.execute();
+            System.out.println("3");
 
             PreparedStatement reformat = connection.prepareStatement(
                     "ALTER TABLE t ALTER COLUMN id INTEGER;" +
@@ -56,16 +60,18 @@ public class SearchModel {
                     "ALTER TABLE t ALTER COLUMN Price INTEGER;");
             reformat.execute();
             System.out.println((query.length()/3) + 1);
-//            String format = formatQuery("astic", connection);
+            String format = formatQuery("astic", connection);
 
             PreparedStatement search = connection.prepareStatement(
                     "SELECT * FROM t WHERE " + filter + "Name LIKE ? ORDER BY " + controller.sortCategory + order);
             search.setString(1, query);
+            System.out.println("4");
             ResultSet queryResult = search.executeQuery();
 
             List<String> headers = Arrays.asList("Name", "Price", "Furniture Type", "Colour",
                                                    "Materials", "Size", "Quantity", "Company", "Style", "Weight");
             while (queryResult.next()) {
+                System.out.println("5");
                 StringBuilder itemString = new StringBuilder(queryResult.getInt("id") + "\t");
                 for (int i = 0; i < headers.size(); i++) {
                     itemString.append(queryResult.getString(headers.get(i)));
@@ -98,7 +104,9 @@ public class SearchModel {
     }
 
     private String recursiveFormatQuery (String formattedQuery, String query, int depth, Connection conn) throws SQLException {
-//        System.out.println(query);
+        System.console().printf(query + "\n");
+        System.console().printf("\n");
+
         formattedQuery += " UNION SELECT * FROM t WHERE Name LIKE '%" + query + "%'";
         if(depth > 0) {
             for (int i = 0; i < query.length(); i++) {

--- a/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
+++ b/src/main/java/furnitureCatalogue/SearchPackage/SearchModel.java
@@ -43,7 +43,10 @@ public class SearchModel {
                     + " AND " + controller.ranges.get(s).get(1) + " AND ";
         }
         // Remove trailing " AND "
-        filter = filter.substring(0, filter.length()-4);
+        if(!filter.isEmpty()) {
+            filter = filter.substring(0, filter.length() - 4);
+            filter = "WHERE " + filter;
+        }
 
         try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:")) {
             PreparedStatement load = connection.prepareStatement(
@@ -62,7 +65,7 @@ public class SearchModel {
             reformat.execute();
 
             PreparedStatement searchFilter = connection.prepareStatement("(" + format +
-                    ") INTERSECT SELECT * FROM t WHERE " + filter + "ORDER BY " + controller.sortCategory + order);
+                    ") INTERSECT SELECT * FROM t " + filter + "ORDER BY " + controller.sortCategory + order);
 //            searchFilter.setString(1, query);
             ResultSet queryResult = searchFilter.executeQuery();
 
@@ -101,7 +104,7 @@ public class SearchModel {
         for(String s : permutations) {
             formattedQuery += " UNION SELECT * FROM t WHERE Name LIKE '%" + s + "%'";
         }
-        System.out.println(formattedQuery);
+//        System.out.println(formattedQuery);
         return formattedQuery;
     }
 


### PR DESCRIPTION
Currently all that the main branch offers is allowing input of a substring of the item rather than the entire name. This branch expands upon relevancy search to include the following features:
* Words in the name can be skipped (still must be in order though working around that would take a lot more time).
* Depending on length of the search query up to 4 typos are permitted

The current setup isn't perfect, (in some cases it may be too lenient). That being said the actual logic and implementation is stable enough that altering the system any further shouldn't break the entire program anymore.